### PR TITLE
Add assertions to iP code

### DIFF
--- a/src/main/java/sleepy/taskstorage/TaskList.java
+++ b/src/main/java/sleepy/taskstorage/TaskList.java
@@ -83,6 +83,7 @@ public class TaskList {
             break;
         default:
             // Should never reach here - parser should have caught invalid command
+            assert false : "Parser did not parse command correctly";
             throw new IllegalArgumentException("Incorrect command!");
         }
     }
@@ -94,14 +95,20 @@ public class TaskList {
      * @param taskNumber Task number to be handled.
      */
     public void handleTask(String operation, int taskNumber) throws IllegalArgumentException {
-        if (operation.equals("mark")) {
+        assert taskNumber >= 1 && taskNumber <= tasks.size() : "Invalid task number!";
+        switch (operation) {
+        case "mark":
             markTaskAsDone(taskNumber);
-        } else if (operation.equals("unmark")) {
+            break;
+        case "unmark":
             markTaskAsUndone(taskNumber);
-        } else if (operation.equals("delete")) {
+            break;
+        case "delete":
             deleteTask(taskNumber);
-        } else {
+            break;
+        default:
             // Should never reach here, parser should have detected invalid operation
+            assert false : "Parser did not parse command correctly";
             throw new IllegalArgumentException("Invalid operation on a task!");
         }
     }
@@ -143,6 +150,7 @@ public class TaskList {
             break;
         default:
             // Should never reach here - parser should have caught invalid task type
+            assert false : "Parser did not parse command correctly";
             throw new IllegalArgumentException("This is not a task!");
         }
         tasks.add(createdTask);
@@ -182,6 +190,7 @@ public class TaskList {
             ResponseHandler.appendLineToResponse("Nice! I've marked this task as done:");
             ResponseHandler.appendLineToResponse(targetTask.getDescription());
         }
+        assert targetTask.isDone() == "true" : "Task was not marked as done correctly!";
     }
 
     /**
@@ -197,6 +206,7 @@ public class TaskList {
             ResponseHandler.appendLineToResponse("OK, I've marked this task as not done yet:");
             ResponseHandler.appendLineToResponse(targetTask.getDescription());
         }
+        assert targetTask.isDone() == "false" : "Task was not marked as undone correctly!";
     }
 
     /**

--- a/src/main/java/sleepy/taskstorage/TaskList.java
+++ b/src/main/java/sleepy/taskstorage/TaskList.java
@@ -67,6 +67,7 @@ public class TaskList {
                 break;
             case "find":
                 String keywords = parsedCommand[1];
+                assert !keywords.isEmpty() : "Empty find field was not detected by parser";
                 ResponseHandler.appendLineToResponse("Here are the matching tasks in your list:");
                 int i = 1;
                 for (Task task: tasks) {
@@ -80,6 +81,8 @@ public class TaskList {
                 addTask(accessCommand);
                 break;
             default:
+                // Should never reach here
+                assert false : "Parser did not parse command correctly";
                 throw new IllegalArgumentException("Invalid command!");
             }
         } catch (NumberFormatException n) {

--- a/src/main/java/sleepy/tools/Parser.java
+++ b/src/main/java/sleepy/tools/Parser.java
@@ -10,11 +10,12 @@ public class Parser {
     /**
      * Parses the given command.
      *
-     * @param command Command from the user to be parsed.
+     * @param input Input from the user to be parsed.
      * @return Parsed command, as an array of strings.
      * @throws IllegalArgumentException If the command is of an invalid form.
      */
-    public static String[] parse(String command) throws IllegalArgumentException {
+    public static String[] parse(String input) throws IllegalArgumentException {
+        String command = input.trim();
         switch (command) {
         case "mark":
             // Fallthrough
@@ -34,12 +35,16 @@ public class Parser {
             return new String[]{"list"};
         default:
             if (command.startsWith("mark ")) {
+                assert command.startsWith("mark ") : "Command should start with 'mark '";
                 return new String[]{ "mark", command.substring(5) };
             } else if (command.startsWith("unmark ")) {
+                assert command.startsWith("unmark ") : "Command should start with 'unmark '";
                 return new String[]{ "unmark", command.substring(7) };
             } else if (command.startsWith("delete ")) {
+                assert command.startsWith("delete ") : "Command should start with 'delete '";
                 return new String[]{"delete", command.substring(7)};
             } else if (command.startsWith("find ")) {
+                assert command.startsWith("find ") : "Command should start with 'find '";
                 return new String[]{"find", command.substring(5)};
             } else {
                 return new String[]{"add", command};
@@ -59,8 +64,10 @@ public class Parser {
         boolean isDeadline = task.startsWith("deadline ");
         boolean isEvent = task.startsWith("event ");
         if (isToDo) {
+            assert task.startsWith("todo ") : "Task should start with 'todo '";
             return new String[]{ "todo", task.substring(5) };
         } else if (isDeadline) {
+            assert task.startsWith("deadline ") : "Task should start with 'deadline '";
             String[] details = task.substring(9).split(" /by ");
             if (details.length == 1) {
                 throw new IllegalArgumentException("Missing the task description or the '/by' field! Try again.");
@@ -70,6 +77,7 @@ public class Parser {
                 return new String[]{ "deadline", details[0], details[1] };
             }
         } else if (isEvent) {
+            assert task.startsWith("event ") : "Task should start with 'event '";
             String[] firstSplit = task.substring(6).split(" /from ");
             if (firstSplit.length == 1) {
                 throw new IllegalArgumentException("Missing the task description or the '/from' field! Try again.");

--- a/src/main/java/sleepy/tools/ResponseHandler.java
+++ b/src/main/java/sleepy/tools/ResponseHandler.java
@@ -33,6 +33,7 @@ public class ResponseHandler {
     public static String returnResponse() {
         String response = responseString.toString();
         responseString.setLength(0);
+        assert responseString.length() == 0 : "Chatbot cache should be cleared after responding";
         return response;
     }
 }


### PR DESCRIPTION
Add assertions to iP code

The iP code needs assertions to check at key points of the code if the integral elements, such as the parser and chatbot cache, have failed.

These assertions will enable verification that the components of the Sleepy chatbot are running as intended.